### PR TITLE
[BUGFIX] Compatibilité avec stylelint 16.3.0

### DIFF
--- a/config/extendedStylelintOrderConfig.js
+++ b/config/extendedStylelintOrderConfig.js
@@ -5,7 +5,7 @@ module.exports = ({
   'border-in-box-model': borderInBoxModel = false,
   'empty-line-between-groups': emptyLineBetweenGroups = false,
 } = {}) => ({
-  plugins: ['stylelint-order', path.join(__dirname, '../plugin')],
+  plugins: ['stylelint-order', path.join(__dirname, '../plugin/index.js')],
   rules: {
     'order/properties-order': [],
     'property-no-unknown': [


### PR DESCRIPTION
## :unicorn: Problème
Le chemin d'import du plugin fait planter stylelint 16.3.0 avec l'erreur ERR_UNSUPPORTED_DIR_IMPORT, voir https://app.circleci.com/pipelines/github/1024pix/pix-editor/6106/workflows/593d738c-60a4-4f13-8e18-2d0f02befa00/jobs/28679

## :robot: Proposition
Compléter le chemin d'import avec le nom du fichier.

## :rainbow: Remarques
N/A

## :100: Pour tester
N/A